### PR TITLE
alter version logic

### DIFF
--- a/run_model/aci.py
+++ b/run_model/aci.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
@@ -36,10 +37,13 @@ def create_and_start_container(
     )
 
     # before v4.0, the containers are started using /opt/docker_run.py
-    if tag == "dev" or tag >= "v4":
-        command = ["/app/.venv/bin/python", "-m", "nhp.docker"]
-    else:
-        command = ["/opt/docker_run.py"]
+    match = re.match(r"^v(\d+)\.", tag)
+    before_v4 = match and int(match.group(1)) < 4
+    command = (
+        ["/opt/docker_run.py"]
+        if before_v4
+        else ["/app/.venv/bin/python", "-m", "nhp.docker"]
+    )
 
     container = Container(
         name=model_id,


### PR DESCRIPTION
useful, as it allows us to use pr containers. the prior logic checked to see if we use a dev container, or a version greater than v4. any other app_version would go back to the old way of starting the code in the containers. so if we tried to run a pr-xyz container it would try to start up in the old way and fail.

there was another subtle bug, if we had a version like "v10.0", this would compare against "v4" and be less than it. so at most we could have run to "v9.0". this handles that better by extracting the value as an int.
