### PR TITLE
handles case of container instance view being None

### DIFF
--- a/status/helpers.py
+++ b/status/helpers.py
@@ -8,11 +8,12 @@ def get_container_group_instance_state(
     client: ContainerInstanceManagementClient,
     resource_group: str,
 ) -> dict:
-    container = (
-        client.container_groups.get(resource_group, container_group_name)
-        .containers[0]
-        .instance_view.current_state
-    )
+    container = client.container_groups.get(
+        resource_group, container_group_name
+    ).containers[0]
+
+    if container.instance_view is None:
+        return {}
 
     if (
         config.AUTO_DELETE_COMPLETED_CONTAINERS


### PR DESCRIPTION
if you try to run get_container_group_instance_state too soon after creating a container group, the instance_view object will be None.

This change checks for that and returns an empty dict instead of trying to access properties on None, which would raise an error.
