### PR TITLE
updates to match changes in NHP ACI

### DIFF
--- a/run_model.py
+++ b/run_model.py
@@ -17,9 +17,12 @@ def run_model(req: func.HttpRequest) -> func.HttpResponse:
     save_full_model_results = (
         req.params.get("save_full_model_results", "").lower() == "true"
     )
+    results_viewable = req.params.get("results_viewable", "").lower() == "true"
     # submit model run
     try:
-        res = create_model_run(params, app_version, save_full_model_results)
+        res = create_model_run(
+            params, app_version, save_full_model_results, results_viewable
+        )
         status_code = 200
     except Exception as e:
         res = {"error": {"type": type(e).__name__, "text": str(e)}}

--- a/status.py
+++ b/status.py
@@ -8,19 +8,22 @@ bp_status = func.Blueprint()
 logger = logging.getLogger(__name__)
 
 
-@bp_status.route(route="model_run_status/{id}", auth_level=func.AuthLevel.FUNCTION)
+@bp_status.route(
+    route="model_run_status/{dataset}/{id}", auth_level=func.AuthLevel.FUNCTION
+)
 def model_run_status(req: func.HttpRequest) -> func.HttpResponse:
     logging.info("getting status for model run")
 
-    container_group_name = req.route_params.get("id")
+    dataset = req.route_params.get("dataset")
+    model_run_id = req.route_params.get("id")
     try:
-        res = get_model_run_status(container_group_name)
+        res = get_model_run_status(dataset, model_run_id)
 
         if res:
             status_code = 200
         else:
             status_code = 404
-            res = {"error": f"no model run found for f{container_group_name}"}
+            res = {"error": f"no model run found for {dataset}/{model_run_id}"}
             logger.error(res["error"])
     except Exception as e:
         res = {"error": {"type": type(e).__name__, "text": str(e)}}


### PR DESCRIPTION
see https://github.com/The-Strategy-Unit/nhp_aci/pull/21

- the status endpoint should now be `{dataset}/{model_run_id}` so we can call `get_model_run_status` with those parameters (which are the partition and row key in table storage)
- the `viewable` flag is now passed in as a url argument to the run model endpoint